### PR TITLE
Fix linting issues, remove stuttering from New

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A cuckoo filter supports following operations:
 ```go
 import "github.com/irfansharif/cfilter"
 
-cf := cfilter.NewCFilter()
+cf := cfilter.New()
 
 // inserts 'bongiorno' to the filter
 cf.Insert([]byte("bongiorno"))  

--- a/cfilter.go
+++ b/cfilter.go
@@ -7,7 +7,7 @@ import (
 )
 
 // The maximum number of times we kick down items/displace from their buckets
-const kMaxCuckooCount = 500
+const maxCuckooCount = 500
 
 // The number of buckets in the filter
 const cfSize = (1 << 18) / bSize
@@ -20,9 +20,9 @@ type CFilter struct {
 	buckets []bucket
 }
 
-// NewCFilter returns a new CFilter object. It's Insert, Lookup, Delete and
+// New returns a new CFilter object. It's Insert, Lookup, Delete and
 // Size behave as their names suggest.
-func NewCFilter() *CFilter {
+func New() *CFilter {
 	cf := new(CFilter)
 
 	cf.size = 0
@@ -48,7 +48,7 @@ func (cf *CFilter) Insert(item []byte) bool {
 	}
 
 	i := [2]uint{j, k}[rand.Intn(2)]
-	for n := 0; n < kMaxCuckooCount; n++ {
+	for n := 0; n < maxCuckooCount; n++ {
 		f = cf.buckets[i].swap(f)
 		i ^= hashfp(f) % cfSize
 

--- a/cfilter_test.go
+++ b/cfilter_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestMultipleInsertions(t *testing.T) {
-	cf := NewCFilter()
+	cf := New()
 
 	fd, err := os.Open("/usr/share/dict/words")
 	if err != nil {
@@ -42,7 +42,7 @@ func TestMultipleInsertions(t *testing.T) {
 }
 
 func TestBasicInsertion(t *testing.T) {
-	cf := NewCFilter()
+	cf := New()
 	if !cf.Insert([]byte("bongiorno")) {
 		t.Errorf("Wasn't able to insert very first word, 'bongiorno'")
 	}
@@ -71,7 +71,7 @@ func TestBasicInsertion(t *testing.T) {
 }
 
 func TestInitialization(t *testing.T) {
-	cf := NewCFilter()
+	cf := New()
 	size := cf.Size()
 	if size != 0 {
 		t.Errorf("Expected initial size to be 0, not %d", size)
@@ -79,7 +79,7 @@ func TestInitialization(t *testing.T) {
 }
 
 func BenchmarkInsertionAndDeletion(b *testing.B) {
-	cf := NewCFilter()
+	cf := New()
 	for n := 0; n < b.N; n++ {
 		cf.Insert([]byte("bongiorno"))
 		cf.Delete([]byte("bongiorno"))


### PR DESCRIPTION
- No need to have CFilter as part of the New, since we're in the cfilter
  package
- don't use leading k in Go names; const kMaxCuckooCount
  should be maxCuckooCount (golint)
