### PR TITLE
fix cfilter.Insert(...) rebalancing

### DIFF
--- a/cfilter.go
+++ b/cfilter.go
@@ -57,7 +57,7 @@ func (cf *CFilter) Insert(item []byte) bool {
 	i := [2]uint{j, k}[rand.Intn(2)]
 	for n := uint(0); n < cf.kicks; n++ {
 		f = cf.buckets[i].swap(f)
-		i ^= hashfp(f) % cf.size
+		i = (i ^ hashfp(f)) % cf.size
 
 		if cf.buckets[i].insert(f) {
 			cf.count++


### PR DESCRIPTION
Fixes #8.
The modulo operator was incorrectly being applied to the result of
the hash function, the result of which was then XOR-ed to be the new search
index. This opened up the possibility for the index to be greater than the
filter size resulting in an index out of range panic.